### PR TITLE
use Composer package information for Bundle Information in "Bundles" grid

### DIFF
--- a/src/Xliff2Bundle/Xliff2Bundle.php
+++ b/src/Xliff2Bundle/Xliff2Bundle.php
@@ -13,14 +13,20 @@ namespace Xliff2Bundle;
 use Xliff2Bundle\DependencyInjection\Compiler\Xliff20CompilerPass;
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
 use Pimcore\Extension\Bundle\PimcoreBundleInterface;
+use Pimcore\Extension\Bundle\Traits\PackageVersionTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * Class AmazonMarketplaceBundle
- * @package AmazonMarketplaceBundle
- */
 class Xliff2Bundle extends AbstractPimcoreBundle implements PimcoreBundleInterface
 {
+    use PackageVersionTrait;
+
+    const PACKAGE_NAME = 'asioso/pimcore-xliff2_0-module';
+
+    protected function getComposerPackageName()
+    {
+        return self::PACKAGE_NAME;
+    }
+
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
@@ -32,24 +38,8 @@ class Xliff2Bundle extends AbstractPimcoreBundle implements PimcoreBundleInterfa
         return 'Asioso - Xliff 2.0 Bundle';
     }
 
-    /**
-     * Bundle description as shown in extension manager
-     *
-     * @return string
-     */
-    public function getDescription()
-    {
-        return "";
-    }
-
-    public function getVersion()
-    {
-        return 'v1.0';
-    }
-
     public static function getSolutionVersion()
     {
-        return "v1.0";
+        return $this->getVersion();
     }
-
 }


### PR DESCRIPTION
Hi!

Added common improvement to use Composer Information for show in "Bundles" Grid by  Pimcore\Extension\Bundle\Traits\PackageVersionTrait. In addition I've fixed couple things:
- Removed non-valid class name
- Removed getDescription, becuase it works the same and return empty string by default. Since Pimcore 6.7 it returns description from composer.json in PackageVersionTrait.
- getSolutionVersion() - it's not present in abstract classes or interfaces, but might be used for some internal tools. I suggest to use $this->getVersion instead copy code or if method isn't used - remove it.

Please review, 